### PR TITLE
add test to verify that environment variables don't leak into module file of subsequent installations

### DIFF
--- a/test/framework/sandbox/easybuild/easyblocks/t/toy.py
+++ b/test/framework/sandbox/easybuild/easyblocks/t/toy.py
@@ -192,3 +192,10 @@ class EB_toy(ExtensionEasyBlock):
         txt = super(EB_toy, self).make_module_extra()
         txt += self.module_generator.set_environment('TOY', os.getenv('TOY', '<TOY_env_var_not_defined>'))
         return txt
+
+    def make_module_req_guess(self):
+        """Extra paths for environment variables to consider"""
+        guesses = super(EB_toy, self).make_module_req_guess()
+        if self.name == 'toy':
+            guesses['CPATH'].append('toy-headers')
+        return guesses


### PR DESCRIPTION
@lexming This test passes on current `5.0.x` branch, but fails when using the changes implemented in https://github.com/easybuilders/easybuild-framework/pull/4653, because `ModuleLoadEnvironment` is a singleton class (it shouldn't be)